### PR TITLE
fix(Error): add ErrorType to error message

### DIFF
--- a/error.go
+++ b/error.go
@@ -66,7 +66,7 @@ func ErrorInternalServerError(msg string, errType ErrorType) CommonError {
 }
 
 func (e CommonError) Error() string {
-	return e.Msg
+	return string(e.ErrorType) + ": " + e.Msg
 }
 
 // 内部向けのスタックトレースとかを表示する


### PR DESCRIPTION
Error()でエラーメッセージを表示する際に
```
{ErrorType}: {Message}
```
のフォーマットで表示されるようにした。