### PR TITLE
feat(error): add ErrorTypeEqual

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package merrors
 
 import (
 	"net/http"
+	"reflect"
 	"runtime"
 	"strconv"
 )
@@ -76,4 +77,30 @@ func (e CommonError) InternalErrorJson() map[string]interface{} {
 	json["msg"] = e.Msg
 	json["stackTrace"] = e.StackTrace
 	return json
+}
+
+// 以下の条件のいずれかを満たす場合にはtrue、それ以外の場合にはfalseを返す
+// - x, y がDeepEqualである
+// - x, y がいずれもCommonErrorであり、かつErrorTypeが同一
+// 異常系のテスト時に、期待したErrorTypeが返っているか確認するために使用することを想定
+func ErrorTypeEqual(x error, y error) bool {
+	if reflect.DeepEqual(x, y) {
+		return true
+	}
+
+	cErrX, ok := x.(CommonError)
+	if !ok {
+		return false
+	}
+
+	cErrY, ok := y.(CommonError)
+	if !ok {
+		return false
+	}
+
+	if cErrX.ErrorType == cErrY.ErrorType {
+		return true
+	}
+
+	return false
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,55 @@
+package merrors
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrorTypeEqual(t *testing.T) {
+	tests := []struct {
+		x    error
+		y    error
+		want bool
+	}{
+		// 非CommonErrorの場合、reflect.DeepEqualで判断
+		{
+			x:    errors.New("same_message"),
+			y:    errors.New("same_message"),
+			want: true,
+		},
+		{
+			x:    errors.New("different_message_1"),
+			y:    errors.New("different_message_2"),
+			want: false,
+		},
+		// CommonError同士の場合、ErrorTypeが同じであればMessageが異なってもtrue
+		{
+			x:    ErrorBadRequest("different_message_1", "same_type"),
+			y:    ErrorBadRequest("different_message_2", "same_type"),
+			want: true,
+		},
+		// Messageが同じでもErrorTypeが違うならfalse
+		{
+			x:    ErrorBadRequest("same_message", "different_type_1"),
+			y:    ErrorBadRequest("same_message", "different_type_2"),
+			want: false,
+		},
+		// CommonErrorとそれ以外のエラーの比較は必ずfalse
+		{
+			x:    errors.New("same_message"),
+			y:    ErrorBadRequest("same_message", "type"),
+			want: false,
+		},
+		{
+			x:    ErrorBadRequest("same_message", "type"),
+			y:    errors.New("same_message"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		if got := ErrorTypeEqual(tt.x, tt.y); got != tt.want {
+			t.Errorf("got %v, want %v", got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
テスト用に以下のような関数が欲しくなったので追加しました。

- 以下の条件のいずれかを満たす場合にはtrue、それ以外の場合にはfalseを返す
    - x, y がDeepEqualである
    - x, y がいずれもCommonErrorであり、かつErrorTypeが同一

異常系のテスト時に、期待したErrorTypeが返っているか確認するために使用することを想定