### PR TITLE
chore(error): "error_type"であっても値を入れられるようにする

### DIFF
--- a/error.go
+++ b/error.go
@@ -24,12 +24,12 @@ type ErrorResponse struct {
 	ErrorType ErrorType
 }
 
-type ErrorResponseCamelCase struct {
+type errorResponseCamelCase struct {
 	Error     string
 	ErrorType ErrorType `json:"errorType"`
 }
 
-type ErrorResponseSnakeCase struct {
+type errorResponseSnakeCase struct {
 	Error     string
 	ErrorType ErrorType `json:"error_type"`
 }
@@ -37,7 +37,7 @@ type ErrorResponseSnakeCase struct {
 // UnmarshalJSON で上書き
 // Go以外の言語についてはKey名がsnake_caseになるものがあるので、そのAPIのレスポンスのハンドリングで困ることがあるから。
 func (r *ErrorResponse) UnmarshalJSON(data []byte) error {
-	var c ErrorResponseCamelCase
+	var c errorResponseCamelCase
 	if err := json.Unmarshal(data, &c); err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func (r *ErrorResponse) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	var s ErrorResponseSnakeCase
+	var s errorResponseSnakeCase
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -1,7 +1,9 @@
 package merrors
 
 import (
+	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 )
 
@@ -50,6 +52,53 @@ func TestErrorTypeEqual(t *testing.T) {
 	for _, tt := range tests {
 		if got := ErrorTypeEqual(tt.x, tt.y); got != tt.want {
 			t.Errorf("got %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func TestErrorResponseFromJson(t *testing.T) {
+	tests := []struct {
+		in   []byte
+		want ErrorResponse
+	}{
+		{
+			in: []byte(`{"error":"case_1", "errorType": "snake_case"}`),
+			want: ErrorResponse{
+				Error:     "case_1",
+				ErrorType: "snake_case",
+			},
+		},
+		{
+			in: []byte(`{"error":"case2", "errorType": "camelCase"}`),
+			want: ErrorResponse{
+				Error:     "case2",
+				ErrorType: "camelCase",
+			},
+		},
+		{
+			in: []byte(`{"error":"case_3", "error_type": "snake_case"}`),
+			want: ErrorResponse{
+				Error:     "case_3",
+				ErrorType: "snake_case",
+			},
+		},
+		{
+			in: []byte(`{"error":"case4", "error_type": "camelCase"}`),
+			want: ErrorResponse{
+				Error:     "case4",
+				ErrorType: "camelCase",
+			},
+		},
+	}
+	for _, tt := range tests {
+		e := &ErrorResponse{}
+		if err := json.Unmarshal(tt.in, e); err != nil {
+			t.Errorf("err: %v", err)
+			continue
+		}
+
+		if !reflect.DeepEqual(*e, tt.want) {
+			t.Errorf("expected: %v, result: %v", tt.want, e)
 		}
 	}
 }


### PR DESCRIPTION
# why

ErrorTypeのkey名がsnake_caseとcamelCaseでUnmarshalできたりできなかったりする。

# what

- json tagは複数key名を指定できない
- 一旦、複数の構造体をprivateにして作り、そこにUnmarshalし、値をcopyすることによって解決